### PR TITLE
Update PlatformDispatcher.onViewFocusChange docs to add See also

### DIFF
--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -369,6 +369,8 @@ class PlatformDispatcher {
   ///   * [ViewFocusState] for a list of allowed focus transitions.
   ///   * [ViewFocusDirection] for a list of allowed focus directions.
   ///   * [ViewFocusEvent], which is the event object provided to the callback.
+  ///   * [WidgetsBindingObserver.didChangeViewFocus], for a mechanism to observe
+  ///     view focus changes.
   ViewFocusChangeCallback? get onViewFocusChange => _onViewFocusChange;
   ViewFocusChangeCallback? _onViewFocusChange;
   // ignore: unused_field, field will be used when platforms other than web use these focus APIs.


### PR DESCRIPTION
Add `[WidgetsBindingObserver.didChangeViewFocus]` to the `See also` section of `PlatformDispatcher.onViewFocusChange` documentation to clarify how to observe focus changes at the widgets layer.

---
*PR created automatically by Jules for task [6798278877425777825](https://jules.google.com/task/6798278877425777825) started by @loic-sharma*