### PR TITLE
Fix iOS physical keyboard dead key composed character replacement

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2299,10 +2299,14 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
   NSMutableArray<FlutterTextSelectionRect*>* copiedRects =
       [[NSMutableArray alloc] initWithCapacity:[_selectionRects count]];
-  NSAssert([_selectedTextRange.start isKindOfClass:[FlutterTextPosition class]],
+  UITextRange* rangeToReplace = self.markedTextRange != nil ? self.markedTextRange : _selectedTextRange;
+  NSAssert([rangeToReplace.start isKindOfClass:[FlutterTextPosition class]],
            @"Expected a FlutterTextPosition for position (got %@).",
-           [_selectedTextRange.start class]);
-  NSUInteger insertPosition = ((FlutterTextPosition*)_selectedTextRange.start).index;
+           [rangeToReplace.start class]);
+  NSUInteger insertPosition = ((FlutterTextPosition*)rangeToReplace.start).index;
+  NSUInteger endPosition = ((FlutterTextPosition*)rangeToReplace.end).index;
+  NSInteger lengthDelta = text.length - (endPosition - insertPosition);
+
   for (NSUInteger i = 0; i < [_selectionRects count]; i++) {
     NSUInteger rectPosition = _selectionRects[i].position;
     if (rectPosition == insertPosition) {
@@ -2312,9 +2316,11 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                                 position:rectPosition + j
                                         writingDirection:_selectionRects[i].writingDirection]];
       }
+    } else if (rectPosition > insertPosition && rectPosition < endPosition) {
+      // Do not copy rects that are inside the replaced range.
     } else {
-      if (rectPosition > insertPosition) {
-        rectPosition = rectPosition + text.length;
+      if (rectPosition >= endPosition) {
+        rectPosition = rectPosition + lengthDelta;
       }
       [copiedRects addObject:[FlutterTextSelectionRect
                                  selectionRectWithRect:_selectionRects[i].rect
@@ -2327,7 +2333,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   [self resetScribbleInteractionStatusIfEnding];
   self.selectionRects = copiedRects;
   _selectionAffinity = kTextAffinityDownstream;
-  [self replaceRange:_selectedTextRange withText:text];
+  [self replaceRange:rangeToReplace withText:text];
 }
 
 - (UITextPlaceholder*)insertTextPlaceholderWithSize:(CGSize)size API_AVAILABLE(ios(13.0)) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -689,8 +689,17 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   XCTAssertEqualObjects(inputView.text, @"");
 }
 
-// This tests the workaround to fix an iOS 16 bug
-// See: https://github.com/flutter/flutter/issues/111494
+- (void)testMacUmlaut {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [self setClientId:123 configuration:config];
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  [inputView setMarkedText:@"¨" selectedRange:NSMakeRange(1, 0)];
+  [inputView insertText:@"ü"];
+  XCTAssertEqualObjects(inputView.text, @"ü");
+}
+
 - (void)testSystemOnlyAddingPartialComposedCharacter {
   NSDictionary* config = self.mutableTemplateCopy;
   [self setClientId:123 configuration:config];


### PR DESCRIPTION
Fixes an issue where typing composed characters with a physical keyboard on iOS inserts both the base modifier and the composed character.

---
*PR created automatically by Jules for task [3919220721839765987](https://jules.google.com/task/3919220721839765987) started by @loic-sharma*